### PR TITLE
docs: Fix a typo in README

### DIFF
--- a/README
+++ b/README
@@ -65,7 +65,7 @@ rather flexible.
     # store pwd in var on exit
     var=$(shfm)
 
-    # store pwd in a file one exit
+    # store pwd in a file on exit
     shfm > file
 
 For ease of use, a wrapper function can be added to your .shellrc (.bashrc, etc).


### PR DESCRIPTION
one exit -> on exit