### PR TITLE
Match hidden files that begin with two dots

### DIFF
--- a/shfm
+++ b/shfm
@@ -136,9 +136,18 @@ list_print() {
     end=$((bottom + 1))
     mid=$((bottom / 4 < 5 ? 1 : bottom / 4))
 
-    case $1$# in
-        '*1')      set -- empty ;;
-        '.[!.]*1') set -- 'no hidden files'
+    case $1:$# in
+    '*:1')
+        [ -e "$1" ] || set -- empty
+        ;;
+    '.[!.]*':2)
+        if ! [ -e "$1" ] && ! [ -e "$2" ]; then
+            set -- 'no hidden files'
+        elif [ -e "$1" ]; then
+            set -- "$1"
+        else
+            set -- "$2"
+        fi
     esac
 
     case $hist in
@@ -331,8 +340,8 @@ main() {
 
             .?)
                 case ${hidden:=1} in
-                    1) hidden=0; set -- .[!.]* ;;
-                    *) hidden=1; set -- *      ;;
+                    1) hidden=0; set -- .[!.]* ..?* ;;
+                    *) hidden=1; set -- *           ;;
                 esac
 
                 y=1 y2=1 cur=$1


### PR DESCRIPTION
Admittedly not the most elegant solution but it works as far as I can tell using the files shown below as a test.

```
shfm » tree
.
├── empty/
├── .github/
│   └── workflows/
│       └── main.yml
├── .onlyhidden/
│   ├── ..hidden
│   └── .hidden
├── onlyhidden/
│   ├── ..hidden
│   └── .hidden
├── star/
│   ├── *
│   └── ..?*
├── star2/
│   ├── **
│   └── .[!.]*
├── ..foo
├── LICENSE
├── README
└── shfm*
```

It's very difficult to reason about how any of this works!