### PR TITLE
G keybind (end) wasn't setting $cur so it would open the wrong item.

### DIFF
--- a/shfm
+++ b/shfm
@@ -325,6 +325,7 @@ main() {
             G?)
                 y=$#
                 y2=$(($# < bottom ? $# : bottom))
+                line_print "$y" "$@"
                 redraw "$@"
             ;;
 


### PR DESCRIPTION
line_print $y $@ always sets $cur correctly.

This pull request fixes a small bug with the G keybind. The readme says you can't grab an element from the argument list by index, but there is a way. The line_print function does it.. Here's a stripped down version of line_print to demonstrate:
grab_nth_element() { shift $1; nth_element=$1 }
and it can be used with
grab_nth_element n $@; cur=$nth_element
The shift isn't destructive because it only shifts the local copy of the argument list.