### PR TITLE
fixed bug with search function. added double quotes to stop $ans from…

### DIFF
--- a/shfm
+++ b/shfm
@@ -357,9 +357,11 @@ main() {
             /?)
                 prompt / r
 
-                # word splitting and globbing intentional
+                IFS=
+                # globbing intentional, word splitting is disabled.
                 # shellcheck disable=2086
-                set -- "$ans"*
+                set -- $ans*
+                unset IFS
 
                 case $1$# in
                     "$ans*1") set -- 'no results'

--- a/shfm
+++ b/shfm
@@ -137,7 +137,7 @@ list_print() {
     mid=$((bottom / 4 < 5 ? 1 : bottom / 4))
 
     case $# in
-        1) [ -e "$1" ] || set -- empty
+        1) [ -e "$1" ] || [ "$1" = 'no results' ] || set -- empty
     esac
 
     case $hist in
@@ -359,7 +359,7 @@ main() {
 
                 # word splitting and globbing intentional
                 # shellcheck disable=2086
-                set -- $ans*
+                set -- "$ans"*
 
                 case $1$# in
                     "$ans*1") set -- 'no results'


### PR DESCRIPTION
… word splitting and modified the logic for detecting an empty directory to stop it from overriding the logic for displaying 'no results'.

Searches with no result used to say 'empty' instead of 'no result' and searches with a space, tab, or newline behaved incorrectly.