### PR TITLE
directories print first by default. added d keybind to toggle printing

### DIFF
--- a/README
+++ b/README
@@ -30,6 +30,7 @@ l - open file or directory
 h - go up level
 g - go to top
 G - go to bottom
+d - toggle printing directories first
 q - quit
 : - cd to <input>
 / - search current directory <input>*
@@ -54,7 +55,7 @@ todo
 ________________________________________________________________________________
 
 - [x] sanitize filenames for display.
-- [ ] print directories first (hard).
+- [x] print directories first.
 - [x] fix buggy focus after exit from inline editor.
 - [ ] maybe file operations.
 - [x] add / to directories.

--- a/shfm
+++ b/shfm
@@ -244,6 +244,18 @@ line_format() {
     printf '\r'
 }
 
+populate_dirs_and_files () {
+    dirs=
+    files=
+    IFS=
+    # globbing is intentional, word splitting is disabled.
+    # shellcheck disable=2231
+    for item in $1*; do
+        [ -d "$item" ] && dirs="$dirs$item/" || files="$files$item/"
+    done
+    unset IFS
+}
+
 main() {
     set -e
 
@@ -265,8 +277,16 @@ main() {
 
     esc_c=$(printf '\033')
     bs_char=$(printf '\177')
+    hidden=0
+    dirs_first=1
 
-    set -- *
+    populate_dirs_and_files
+    IFS='/'
+    set -f
+    # word splitting intentional, globbing is disabled.
+    # shellcheck disable=2086
+    set +f -- $dirs $files
+    unset IFS
     cur=$1
 
     term_resize
@@ -290,7 +310,17 @@ main() {
 
             l?|C2|"$esc") # ARROW RIGHT
                 if [ -d "$cur" ] && cd -- "$cur" >/dev/null 2>&1; then
-                    set -- *
+                    if [ "$dirs_first" -eq 0 ]; then
+                        set -- *
+                    else
+                        populate_dirs_and_files
+                        IFS='/'
+                        set -f
+                        # word splitting intentional, globbing is disabled.
+                        # shellcheck disable=2086
+                        set +f -- $dirs $files
+                        unset IFS
+                    fi
                     y=1 y2=1 cur=$1 ltype=
                     redraw "$@"
 
@@ -308,7 +338,17 @@ main() {
                      *) ltype= ;;
                 esac
 
-                set -- *
+                if [ "$dirs_first" -eq 0 ]; then
+                    set -- *
+                else
+                    populate_dirs_and_files
+                    IFS='/'
+                    set -f
+                    # word splitting intentional, globbing is disabled.
+                    # shellcheck disable=2086
+                    set +f -- $dirs $files
+                    unset IFS
+                fi
                 y=1 y2=1 cur=$1 hist=1
                 redraw "$@"
             ;;
@@ -328,11 +368,43 @@ main() {
                 redraw "$@"
             ;;
 
-            .?)
-                case ${hidden:=1} in
-                    1) hidden=0; set -- .* ;;
-                    0) hidden=1; set -- *
+            d?)
+                case $hidden in
+                    0) prefix='' ;;
+                    1) prefix='.'
                 esac
+                [ "$dirs_first" -eq 0 ] && dirs_first=1 || dirs_first=0
+                if [ "$dirs_first" -eq 0 ]; then
+                    set -- "$prefix"*
+                else
+                    populate_dirs_and_files "$prefix"
+                    IFS='/'
+                    set -f
+                    # word splitting intentional, globbing is disabled.
+                    # shellcheck disable=2086
+                    set +f -- $dirs $files
+                    unset IFS
+                fi
+                y=1 y2=1 cur=$1
+                redraw "$@"
+            ;;
+
+            .?)
+                case $hidden in
+                    0) hidden=1; prefix='.' ;;
+                    1) hidden=0; prefix=''
+                esac
+                if [ "$dirs_first" -eq 0 ]; then
+                    set -- "$prefix"*
+                else
+                    populate_dirs_and_files "$prefix"
+                    IFS='/'
+                    set -f
+                    # word splitting intentional, globbing is disabled.
+                    # shellcheck disable=2086
+                    set +f -- $dirs $files
+                    unset IFS
+                fi
 
                 y=1 y2=1 cur=$1
                 redraw "$@"
@@ -349,7 +421,17 @@ main() {
                 esac
 
                 cd -- "${ans:="$0"}" >/dev/null 2>&1|| continue
-                set -- *
+                if [ "$dirs_first" -eq 0 ]; then
+                    set -- *
+                else
+                    populate_dirs_and_files
+                    IFS='/'
+                    set -f
+                    # word splitting intentional, globbing is disabled.
+                    # shellcheck disable=2086
+                    set +f -- $dirs $files
+                    unset IFS
+                fi
                 y=1 y2=1 cur=$1
                 redraw "$@"
             ;;
@@ -357,9 +439,17 @@ main() {
             /?)
                 prompt / r
 
-                # word splitting and globbing intentional
-                # shellcheck disable=2086
-                set -- $ans*
+                if [ "$dirs_first" -eq 0 ]; then
+                    set -- "$ans"*
+                else
+                    populate_dirs_and_files "$ans"
+                    IFS='/'
+                    set -f
+                    # word splitting intentional, globbing is disabled.
+                    # shellcheck disable=2086
+                    set +f -- $dirs $files
+                    unset IFS
+                fi
 
                 case $1$# in
                     "$ans*1") set -- 'no results'
@@ -372,14 +462,34 @@ main() {
 
             -?)
                 cd -- "$OLDPWD" >/dev/null 2>&1|| continue
-                set -- *
+                if [ "$dirs_first" -eq 0 ]; then
+                    set -- *
+                else
+                    populate_dirs_and_files
+                    IFS='/'
+                    set -f
+                    # word splitting intentional, globbing is disabled.
+                    # shellcheck disable=2086
+                    set +f -- $dirs $files
+                    unset IFS
+                fi
                 y=1 y2=1 cur=$1
                 redraw "$@"
             ;;
 
             \~?)
                 cd || continue
-                set -- *
+                if [ "$dirs_first" -eq 0 ]; then
+                    set -- *
+                else
+                    populate_dirs_and_files
+                    IFS='/'
+                    set -f
+                    # word splitting intentional, globbing is disabled.
+                    # shellcheck disable=2086
+                    set +f -- $dirs $files
+                    unset IFS
+                fi
                 y=1 y2=1 cur=$1
                 redraw "$@"
             ;;


### PR DESCRIPTION
directories first because it runs slower when enabled. also, switched $hidden to display hidden files when 1 instead of 0.

I separate directories from files before adding them to the parameter list to force directories to the top of the list. Luckily, directories and file names cannot have / in them so I used / to get around POSIX shell's lack of arrays. I then set IFS to / to pull apart the directories and file names when adding them to the parameter list. Obviously, this takes a longer than a simple set -- *, so I included a keybind, d, to toggle printing directories first. I swapped $hidden to showing normal files when 0 and hidden files when 1 because that makes a lot more sense to me. 