### PR TITLE
fixed bug when moving to parent...

### DIFF
--- a/shfm
+++ b/shfm
@@ -121,7 +121,7 @@ hist_search() {
 
     for file do
         case ${PWD%%/}/$file in
-            "$old_pwd") y=$j y2=$((j > bottom ? mid : j)) cur=$file
+            "$old_pwd") y=$j y2=$((j >= bottom ? mid : j)) cur=$file
         esac
 
         j=$((j + 1))


### PR DESCRIPTION
...when y position of old directory equals bottom

to demonstrate the bug, enter a directory on the nth line such that n is the number of printable lines (excluding the blank line and status line), then exit it by pressing left (or h) and you'll see that the directory you were in is printed at the top of the screen, but your cursor is still on the nth line. list_print shifts the items by y-mid on a greater or equal condition (line 150), but hist_search only adjusts y2 on a greater than condition (line 124) which is why the bug occurs when y=bottom.