### PR TITLE
fixed bug that overwrites saved stty settings

### DIFF
--- a/shfm
+++ b/shfm
@@ -22,7 +22,6 @@ esc() {
 }
 
 term_setup() {
-    stty=$(stty -g)
     stty -icanon -echo
     esc screen_alt h
     esc DECAWM l
@@ -270,6 +269,7 @@ main() {
     cur=$1
 
     term_resize
+    stty=$(stty -g)
     term_setup
 
     trap 'term_reset'  EXIT INT


### PR DESCRIPTION
To reproduce the bug, start shfm, resize your terminal to trigger SIGWINCH's trap, then exit shfm. You'll notice that icanon and echo are disabled even though term_reset should've reset those. At program start, stty is saved so that it can be restored at exit. SIGWINCH's trap calls term_setup which overwrites stty unnecessarily. I moved stty set out of term_setup to avoid this.